### PR TITLE
Don't run scripts on COMMAND + S

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -68,7 +68,7 @@ function setupKeyboardHandlers() {
   const maybeHandleKeypress = (ev :KeyboardEvent, key :string) :any => {
 
     // run script
-    if (key == "Enter" || key == "r" || key == "s") {
+    if (key == "Enter" || key == "r") {
       if (ev.shiftKey) {
         return editor.stopCurrentScript(), true
       } else {


### PR DESCRIPTION
This PR disables running scripts on "Command + S" (which makes it easy to accidentally execute scripts without realizing it).