### PR TITLE
Fix a couple new-checkout build errors

### DIFF
--- a/misc/dev.sh
+++ b/misc/dev.sh
@@ -57,6 +57,9 @@ if ! [ -d "$monaco_build_dir" ] || has_newer "src/monaco" "$monaco_build_dir/mon
   bash misc/build-monaco.sh
 fi
 
+# make build/dev directory if needed
+mkdir -p build/dev
+
 # symlink monaco & zip
 rm -rf build/dev/monaco-* build/dev/zip
 pushd build/dev >/dev/null

--- a/misc/util.sh
+++ b/misc/util.sh
@@ -1,4 +1,5 @@
 export PATH=$PWD/node_modules/.bin:$PATH
+export NODE_OPTIONS=--openssl-legacy-provider
 
 has_newer() {
   DIR=$1


### PR DESCRIPTION
Trying to build using `./misc/dev.sh` on a fresh checkout caused 2 errors
1. `pushd: build/dev: No such file or directory` build/dev doesn't exist, but we try to enter it, so i added it in the util script.

2. When trying to build using `./misc/dev.sh` I get an `ERR_OSSL_EVP_UNSUPPORTED` error, ([full stack trace](https://gist.github.com/msfeldstein/5927b0734a3900881d2f02706d9abbf8)).  It looks like Node has changed a bit in recent updates and we need to add the `--openssl-legacy-provider` flag to run this properly on node19.8.1. 